### PR TITLE
remove border: none from h2 hover selector in letterpress.css

### DIFF
--- a/src/web/content/static/css/letterpress.css
+++ b/src/web/content/static/css/letterpress.css
@@ -610,11 +610,6 @@ h2.sms-h2 a:visited
 }
 
 .sms-results-list h2.sms-h2 a:hover {
-    border: none;
-}
-
-.sms-results-list h2.sms-h2 a:hover {
-    border: none;
     opacity: 1;
 }
 


### PR DESCRIPTION
This is a tentative solution to layout shift identified in #113.

From scanning through the template files I don't think removing this css rule will cause more issues elsewhere, but I haven't tested systematically.