### PR TITLE
125 arrow at bottom of screen falling outside of the screen

### DIFF
--- a/src/web/content/static/css/letterpress.css
+++ b/src/web/content/static/css/letterpress.css
@@ -367,7 +367,7 @@ a.sms-large-font:hover {
 
 /* Home ******************* */
 .sms-home-main-container {
-    height: 80vh;
+    height: 85vh;
     display: flex;
     flex-direction: column;
 }

--- a/src/web/content/static/css/letterpress.css
+++ b/src/web/content/static/css/letterpress.css
@@ -372,12 +372,12 @@ a.sms-large-font:hover {
     flex-direction: column;
 }
 .sms-home-header {
-    height: 20vh;
+    height: 15vh;
 }
 
 .sms-home-intro-txt {
-    margin-top: 5.875rem;
-    padding-top: 1.875rem;
+    margin-top: 3vh;
+    padding-top: 0.5rem;
     border-top: 0.0625rem solid var(--light-gray);
     border-bottom: 0.0625rem solid var(--light-gray);
     padding-bottom: 1rem;


### PR DESCRIPTION
Please look at ticket for how the arrow looks right now. It's falling out of the screen on certain screen sizes. With the fix it's looking like this on 1680 and 1060 screen sizes.
<img width="1352" alt="arrow 1680" src="https://github.com/searchmysite/searchmysite.net/assets/1785755/8edf4322-f34c-4bc6-9492-49ac1efd3e91">
<img width="1138" alt="arrow 1060" src="https://github.com/searchmysite/searchmysite.net/assets/1785755/e2e16b70-0de9-47dc-8376-6c3dcc248a19">

